### PR TITLE
fix: resolve duplicate and incorrect role values in Swagger docs

### DIFF
--- a/src/main/java/com/timekeeper/bibexpo/model/dto/request/CreateUserRequest.java
+++ b/src/main/java/com/timekeeper/bibexpo/model/dto/request/CreateUserRequest.java
@@ -50,6 +50,7 @@ public class CreateUserRequest {
 
     @NotNull(message = "Role is required")
     @Schema(description = "Role to assign to the user", example = "ADMIN",
+            implementation = String.class,
             allowableValues = {"ADMIN", "ORGANIZER_ADMIN", "ORGANIZER_USER", "DISTRIBUTOR"})
     private UserRole role;
 


### PR DESCRIPTION
Fixes #1

Adds `implementation = String.class` to the @Schema annotation on the `role` field in `CreateUserRequest` to prevent Springdoc-OpenAPI from merging all UserRole enum constants with allowableValues, which caused duplicates and exposed the non-creatable ROOT role in the API documentation.

Generated with [Claude Code](https://claude.ai/code)