### PR TITLE
Fix (organization): add user limit validation to prevent reducing max organizer users below active count - #9

### DIFF
--- a/src/main/java/com/timekeeper/bibexpo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/timekeeper/bibexpo/exception/GlobalExceptionHandler.java
@@ -708,4 +708,21 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
     }
+
+    @ExceptionHandler(UserLimitReductionException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidNumberOfUser(
+            UserLimitReductionException ex, WebRequest request) {
+        log.error("Invalid user limit: {}", ex.getMessage());
+
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(HttpStatus.CONFLICT.value())
+                .error("Unprocessable Entity")
+                .message(ex.getMessage())
+                .path(request.getDescription(false).replace("uri=", ""))
+                .build();
+
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
 }

--- a/src/main/java/com/timekeeper/bibexpo/exception/UserLimitReductionException.java
+++ b/src/main/java/com/timekeeper/bibexpo/exception/UserLimitReductionException.java
@@ -1,0 +1,7 @@
+package com.timekeeper.bibexpo.exception;
+
+public class UserLimitReductionException extends RuntimeException {
+    public UserLimitReductionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/timekeeper/bibexpo/repository/UserRepository.java
+++ b/src/main/java/com/timekeeper/bibexpo/repository/UserRepository.java
@@ -99,4 +99,8 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
     long countByOrganizationIdAndEnabledTrueAndDeletedFalse(Long organizationId);
 
     long countByOrganizationIdAndEnabledFalseAndDeletedFalse(Long organizationId);
+
+    //@Query("SELECT COUNT(u) FROM User u WHERE u.organization.id = :orgId AND u.enabled = true AND u.deleted = false")
+    long countByOrganizationIdAndEnabledTrueAndDeletedFalseAndRole(Long organizationId, UserRole role);
+
 }

--- a/src/main/java/com/timekeeper/bibexpo/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/com/timekeeper/bibexpo/service/impl/OrganizationServiceImpl.java
@@ -1,8 +1,6 @@
 package com.timekeeper.bibexpo.service.impl;
 
-import com.timekeeper.bibexpo.exception.OrganizationAlreadyExistsException;
-import com.timekeeper.bibexpo.exception.OrganizationNotFoundException;
-import com.timekeeper.bibexpo.exception.UnauthorizedAccessException;
+import com.timekeeper.bibexpo.exception.*;
 import com.timekeeper.bibexpo.model.dto.request.CreateOrganizationRequest;
 import com.timekeeper.bibexpo.model.dto.request.UpdateOrganizationRequest;
 import com.timekeeper.bibexpo.model.dto.response.OrganizationResponse;
@@ -180,6 +178,8 @@ public class OrganizationServiceImpl implements OrganizationService {
         validateUpdateAuthorization(currentUser, id);
         validateEmailUniqueness(request.getEmail(), organization.getEmail());
         validateTaxIdUniqueness(request.getTaxId(), organization.getTaxId());
+        validateUserLimit(organization,  request);
+
         applyOrganizationUpdates(organization, request);
 
         Organization updatedOrganization = organizationRepository.save(organization);
@@ -331,6 +331,26 @@ public class OrganizationServiceImpl implements OrganizationService {
 
     private String emptyToNull(String value) {
         return (value == null || value.isBlank()) ? null : value;
+    }
+
+    private void validateUserLimit(Organization organization, UpdateOrganizationRequest request){
+        if (request.getMaxOrganizerUsers() == null ||
+                request.getMaxOrganizerUsers().equals(organization.getMaxOrganizerUsers())){
+            return;
+        }
+        long currentNoOfUsers = organization.getUsers()
+                .stream()
+                .filter(u -> u.isEnabled())
+                .count();
+
+        if (request.getMaxOrganizerUsers() < organization.getMaxOrganizerUsers()){
+            long activeOrgUser = userRepository.countByOrganizationIdAndEnabledTrueAndDeletedFalseAndRole(organization.getId(), UserRole.ORGANIZER_USER);
+            if (request.getMaxOrganizerUsers() < activeOrgUser) {
+                throw new UserLimitReductionException(String.format(
+                        "You cannot reduce the user limit below the current number of active users (%d).",
+                         activeOrgUser));
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/timekeeper/bibexpo/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/com/timekeeper/bibexpo/service/impl/OrganizationServiceImpl.java
@@ -1,6 +1,10 @@
 package com.timekeeper.bibexpo.service.impl;
 
-import com.timekeeper.bibexpo.exception.*;
+
+import com.timekeeper.bibexpo.exception.OrganizationAlreadyExistsException;
+import com.timekeeper.bibexpo.exception.OrganizationNotFoundException;
+import com.timekeeper.bibexpo.exception.UnauthorizedAccessException;
+import com.timekeeper.bibexpo.exception.UserLimitReductionException;
 import com.timekeeper.bibexpo.model.dto.request.CreateOrganizationRequest;
 import com.timekeeper.bibexpo.model.dto.request.UpdateOrganizationRequest;
 import com.timekeeper.bibexpo.model.dto.response.OrganizationResponse;
@@ -338,10 +342,6 @@ public class OrganizationServiceImpl implements OrganizationService {
                 request.getMaxOrganizerUsers().equals(organization.getMaxOrganizerUsers())){
             return;
         }
-        long currentNoOfUsers = organization.getUsers()
-                .stream()
-                .filter(u -> u.isEnabled())
-                .count();
 
         if (request.getMaxOrganizerUsers() < organization.getMaxOrganizerUsers()){
             long activeOrgUser = userRepository.countByOrganizationIdAndEnabledTrueAndDeletedFalseAndRole(organization.getId(), UserRole.ORGANIZER_USER);


### PR DESCRIPTION
Prevents users from reducing `maxOrganizerUsers` below the organization's current active organizer user count during an update. Adds `validateUserLimit()` in `OrganizationService`, a `@Query` count method in `UserRepository`, a new `InvalidNumberOfUserException`, and a `422` handler in the `GlobalExceptionHandler`.